### PR TITLE
re-adding `PrimaryVertexProducerAlgorithm` (for now)

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -56,7 +56,6 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
@@ -120,11 +119,6 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
     theTrackClusterizer_ =
         std::make_unique<GapClusterizerInZ>(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
                                                 .getParameter<edm::ParameterSet>("TkGapClusParameters"));
-  } else if (clusteringAlgorithm == "DA") {
-    theTrackClusterizer_ =
-        std::make_unique<DAClusterizerInZ>(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
-                                               .getParameter<edm::ParameterSet>("TkDAClusParameters"));
-    // provide the vectorized version of the clusterizer, if supported by the build
   } else if (clusteringAlgorithm == "DA_vect") {
     theTrackClusterizer_ =
         std::make_unique<DAClusterizerInZ_vect>(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")

--- a/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h
@@ -1,0 +1,94 @@
+/////////////////////////   OBSOLETE    ///////////////////
+#ifndef PrimaryVertexProducerAlgorithm_H
+#define PrimaryVertexProducerAlgorithm_H
+// -*- C++ -*-
+//
+// Package:    PrimaryVertexProducerAlgorithm
+// Class:      PrimaryVertexProducerAlgorithm
+//
+/**\class PrimaryVertexProducerAlgorithm PrimaryVertexProducerAlgorithm.cc RecoVertex/PrimaryVertexProducerAlgorithm/src/PrimaryVertexProducerAlgorithm.cc
+
+ Description: allow redoing the primary vertex reconstruction from a list of tracks, considered obsolete
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Pascal Vanlaer
+//         Created:  Tue Feb 28 11:06:34 CET 2006
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "RecoVertex/VertexPrimitives/interface/VertexReconstructor.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFindingBase.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
+
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
+//#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+#include "RecoVertex/VertexPrimitives/interface/VertexException.h"
+#include <algorithm>
+#include "RecoVertex/PrimaryVertexProducer/interface/VertexHigherPtSquared.h"
+#include "RecoVertex/VertexTools/interface/VertexCompatibleWithBeam.h"
+
+//
+// class declaration
+//
+
+class PrimaryVertexProducerAlgorithm : public VertexReconstructor {
+public:
+  explicit PrimaryVertexProducerAlgorithm(const edm::ParameterSet&);
+  ~PrimaryVertexProducerAlgorithm() override;
+
+  // obsolete method
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& tracks) const override;
+
+  virtual std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& tracks,
+                                                const reco::BeamSpot& beamSpot,
+                                                const std::string& label = "") const;
+  /** Clone method
+   */
+  PrimaryVertexProducerAlgorithm* clone() const override { return new PrimaryVertexProducerAlgorithm(*this); }
+
+  // access to config
+  edm::ParameterSet config() const { return theConfig; }
+  edm::InputTag trackLabel;
+  edm::InputTag beamSpotLabel;
+
+private:
+  using VertexReconstructor::vertices;
+  // ----------member data ---------------------------
+  TrackFilterForPVFindingBase* theTrackFilter;
+  TrackClusterizerInZ* theTrackClusterizer;
+
+  // vtx fitting algorithms
+  struct algo {
+    VertexFitter<5>* fitter;
+    VertexCompatibleWithBeam* vertexSelector;
+    std::string label;
+    bool useBeamConstraint;
+    double minNdof;
+  };
+
+  std::vector<algo> algorithms;
+
+  edm::ParameterSet theConfig;
+  bool fVerbose;
+};
+#endif

--- a/RecoVertex/PrimaryVertexProducer/src/PrimaryVertexProducerAlgorithm.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/PrimaryVertexProducerAlgorithm.cc
@@ -1,0 +1,176 @@
+///////////////   OBSOLETE ////////////////////
+#include "RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h"
+
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+PrimaryVertexProducerAlgorithm::PrimaryVertexProducerAlgorithm(const edm::ParameterSet& conf) : theConfig(conf) {
+  fVerbose = conf.getUntrackedParameter<bool>("verbose", false);
+  trackLabel = conf.getParameter<edm::InputTag>("TrackLabel");
+  beamSpotLabel = conf.getParameter<edm::InputTag>("beamSpotLabel");
+
+  // select and configure the track selection
+  std::string trackSelectionAlgorithm =
+      conf.getParameter<edm::ParameterSet>("TkFilterParameters").getParameter<std::string>("algorithm");
+  if (trackSelectionAlgorithm == "filter") {
+    theTrackFilter = new TrackFilterForPVFinding(conf.getParameter<edm::ParameterSet>("TkFilterParameters"));
+  } else if (trackSelectionAlgorithm == "filterWithThreshold") {
+    theTrackFilter = new HITrackFilterForPVFinding(conf.getParameter<edm::ParameterSet>("TkFilterParameters"));
+  } else {
+    throw VertexException("PrimaryVertexProducerAlgorithm: unknown track selection algorithm: " +
+                          trackSelectionAlgorithm);
+  }
+
+  // select and configure the track clusterizer
+  std::string clusteringAlgorithm =
+      conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<std::string>("algorithm");
+  if (clusteringAlgorithm == "gap") {
+    theTrackClusterizer = new GapClusterizerInZ(
+        conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkGapClusParameters"));
+  }
+  // provide the vectorized version of the clusterizer, if supported by the build
+  else if (clusteringAlgorithm == "DA_vect") {
+    theTrackClusterizer = new DAClusterizerInZ_vect(
+        conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters"));
+  }
+
+  else {
+    throw VertexException("PrimaryVertexProducerAlgorithm: unknown clustering algorithm: " + clusteringAlgorithm);
+  }
+
+  // select and configure the vertex fitters
+  std::vector<edm::ParameterSet> vertexCollections =
+      conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
+
+  for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
+       algoconf != vertexCollections.end();
+       algoconf++) {
+    algo algorithm;
+    std::string fitterAlgorithm = algoconf->getParameter<std::string>("algorithm");
+    if (fitterAlgorithm == "KalmanVertexFitter") {
+      algorithm.fitter = new KalmanVertexFitter();
+    } else if (fitterAlgorithm == "AdaptiveVertexFitter") {
+      algorithm.fitter = new AdaptiveVertexFitter();
+    } else {
+      throw VertexException("PrimaryVertexProducerAlgorithm: unknown algorithm: " + fitterAlgorithm);
+    }
+    algorithm.label = algoconf->getParameter<std::string>("label");
+    algorithm.minNdof = algoconf->getParameter<double>("minNdof");
+    algorithm.useBeamConstraint = algoconf->getParameter<bool>("useBeamConstraint");
+    algorithm.vertexSelector =
+        new VertexCompatibleWithBeam(VertexDistanceXY(), algoconf->getParameter<double>("maxDistanceToBeam"));
+    algorithms.push_back(algorithm);
+  }
+}
+
+PrimaryVertexProducerAlgorithm::~PrimaryVertexProducerAlgorithm() {
+  if (theTrackFilter)
+    delete theTrackFilter;
+  if (theTrackClusterizer)
+    delete theTrackClusterizer;
+  for (std::vector<algo>::const_iterator algorithm = algorithms.begin(); algorithm != algorithms.end(); algorithm++) {
+    if (algorithm->fitter)
+      delete algorithm->fitter;
+    if (algorithm->vertexSelector)
+      delete algorithm->vertexSelector;
+  }
+}
+
+//
+// member functions
+//
+
+// obsolete method, unfortunately required through inheritance from  VertexReconstructor
+std::vector<TransientVertex> PrimaryVertexProducerAlgorithm::vertices(
+    const std::vector<reco::TransientTrack>& tracks) const {
+  throw VertexException("PrimaryVertexProducerAlgorithm: cannot make a Primary Vertex without a beam spot");
+
+  return std::vector<TransientVertex>();
+}
+
+std::vector<TransientVertex> PrimaryVertexProducerAlgorithm::vertices(const std::vector<reco::TransientTrack>& t_tks,
+                                                                      const reco::BeamSpot& beamSpot,
+                                                                      const std::string& label) const {
+  bool validBS = true;
+  VertexState beamVertexState(beamSpot);
+  if ((beamVertexState.error().cxx() <= 0.) || (beamVertexState.error().cyy() <= 0.) ||
+      (beamVertexState.error().czz() <= 0.)) {
+    validBS = false;
+    edm::LogError("UnusableBeamSpot") << "Beamspot with invalid errors " << beamVertexState.error().matrix();
+  }
+
+  //   // get RECO tracks from the event
+  //   // `tks` can be used as a ptr to a reco::TrackCollection
+  //   edm::Handle<reco::TrackCollection> tks;
+  //   iEvent.getByLabel(trackLabel, tks);
+
+  // select tracks
+  std::vector<reco::TransientTrack> seltks = theTrackFilter->select(t_tks);
+
+  // clusterize tracks in Z
+  std::vector<std::vector<reco::TransientTrack> > clusters = theTrackClusterizer->clusterize(seltks);
+  if (fVerbose) {
+    std::cout << " clustering returned  " << clusters.size() << " clusters  from " << seltks.size()
+              << " selected tracks" << std::endl;
+  }
+
+  // vertex fits
+  for (std::vector<algo>::const_iterator algorithm = algorithms.begin(); algorithm != algorithms.end(); algorithm++) {
+    if (!(algorithm->label == label))
+      continue;
+
+    //std::auto_ptr<reco::VertexCollection> result(new reco::VertexCollection);
+    // reco::VertexCollection vColl;
+
+    std::vector<TransientVertex> pvs;
+    for (std::vector<std::vector<reco::TransientTrack> >::const_iterator iclus = clusters.begin();
+         iclus != clusters.end();
+         iclus++) {
+      TransientVertex v;
+      if (algorithm->useBeamConstraint && validBS && ((*iclus).size() > 1)) {
+        v = algorithm->fitter->vertex(*iclus, beamSpot);
+
+      } else if (!(algorithm->useBeamConstraint) && ((*iclus).size() > 1)) {
+        v = algorithm->fitter->vertex(*iclus);
+
+      }  // else: no fit ==> v.isValid()=False
+
+      if (fVerbose) {
+        if (v.isValid())
+          std::cout << "x,y,z=" << v.position().x() << " " << v.position().y() << " " << v.position().z() << std::endl;
+        else
+          std::cout << "Invalid fitted vertex\n";
+      }
+
+      if (v.isValid() && (v.degreesOfFreedom() >= algorithm->minNdof) &&
+          (!validBS || (*(algorithm->vertexSelector))(v, beamVertexState)))
+        pvs.push_back(v);
+    }  // end of cluster loop
+
+    if (fVerbose) {
+      std::cout << "PrimaryVertexProducerAlgorithm::vertices  candidates =" << pvs.size() << std::endl;
+    }
+
+    // sort vertices by pt**2  vertex (aka signal vertex tagging)
+    if (pvs.size() > 1) {
+      sort(pvs.begin(), pvs.end(), VertexHigherPtSquared());
+    }
+
+    return pvs;
+  }
+
+  std::vector<TransientVertex> dummy;
+  return dummy;  //avoid compiler warning, should never be here
+}


### PR DESCRIPTION
Hi @werdmann ,

these are the minimal changes I needed to compile the latest version of the branch.

`PrimaryVertexProducerAlgorithm` could be removed again in the near future, once its use case is clarified.

For the moment, I would say we take `werdmann/revised-primaryvertexproducer_1310pre1` as reference branch.

The recipe to pick up the reference branch from scratch (if needed) is [1] (and should work after this PR is merged).

[1]
```sh
cmsrel CMSSW_13_1_0_pre1
cd CMSSW_13_1_0_pre1/src
cmsenv
git cms-init
git cms-merge-topic werdmann:revised-primaryvertexproducer_1310pre1
git checkout -b revised-primaryvertexproducer_1310pre1
scram build
```